### PR TITLE
Remove unused outputs

### DIFF
--- a/wdl/bowtie2_align/bowtie2_align.wdl
+++ b/wdl/bowtie2_align/bowtie2_align.wdl
@@ -26,7 +26,7 @@ task bowtie2_align {
         tar -zxvf ~{genome_dir_tar} -C ./genome/~{genome_dir} --strip-components 1
 
         echo "--- $(date "+[%b %d %H:%M:%S]") Indexing genome ---"
-        bowtie2 -p ~{ncpu} -1 ~{fastqr1} -2 ~{fastqr2} -x genome/~{genome_dir}/~{index_prefix} --local -S ~{SID}.sam 2> ~{SID}.log
+        bowtie2 -p ~{ncpu} -1 ~{fastqr1} -2 ~{fastqr2} -x genome/~{genome_dir}/~{index_prefix} --local -S /dev/null 2> ~{SID}.log
 
         echo "--- $(date "+[%b %d %H:%M:%S]") Transforming text ---"
         type=$(echo ~{genome_dir}|awk -F_ '{print $NF}')
@@ -38,7 +38,6 @@ task bowtie2_align {
     >>>
 
     output {
-        File bowtie2_output = "${SID}.sam"
         File bowtie2_log = "${SID}.log"
         File bowtie2_report = "${SID}_${genome_dir}_report.txt"
     }

--- a/wdl/mark_duplicates/mark_duplicates.wdl
+++ b/wdl/mark_duplicates/mark_duplicates.wdl
@@ -24,22 +24,16 @@ task markduplicates {
         echo "--- $(date "+[%b %d %H:%M:%S]") Done with ulimit, running markduplicates ---"
         java -Xmx~{memory}g -jar /usr/local/bin/picard.jar  MarkDuplicates \
             I=~{input_bam} \
-            O= ~{output_bam} \
-            CREATE_INDEX=true \
+            O=~{output_bam} \
             VALIDATION_STRINGENCY=SILENT \
             ASSUME_SORT_ORDER=coordinate \
             M=~{SID}.marked_dup_metrics.txt \
             REMOVE_DUPLICATES=false
 
-        echo "--- $(date "+[%b %d %H:%M:%S]") Done with markduplicates, running samtools index ---"
-        samtools index ~{output_bam}
-
-        echo "--- $(date "+[%b %d %H:%M:%S]") Done with samtools index, finished task ---"
+        echo "--- $(date "+[%b %d %H:%M:%S]") Done with markduplicates, finished task ---"
     >>>
 
     output {
-        File bam_file = "${output_bam}"
-        File bam_index = "${output_bam}.bai"
         File metrics = "${SID}.marked_dup_metrics.txt"
     }
 


### PR DESCRIPTION
Potential output files to remove:

- **bowtie2_globin** / **bowtie2_rrna** / **bowtie2_phix** [[x](https://github.com/MoTrPAC/motrpac-rna-seq-pipeline/blob/master/wdl/bowtie2_align/bowtie2_align.wdl)]
  - `bowtie2_output = "${SID}.sam"`
- **md** [[x](https://github.com/MoTrPAC/motrpac-rna-seq-pipeline/blob/master/wdl/mark_duplicates/mark_duplicates.wdl)]
  - `bam_file = "${output_bam}"`
  - `bam_index = "${output_bam}.bai"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Alignment processing no longer produces a SAM file; log and report outputs remain available.
  * Duplicate-marking processing no longer creates or returns a BAM index file.
  * BAM and metrics outputs continue to be provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->